### PR TITLE
SA-673 Adds title to links for screen readers

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -24,7 +24,7 @@ object HmrcBuild extends Build {
   import uk.gov.hmrc.DefaultBuildSettings._
   import uk.gov.hmrc.{SbtBuildInfo, ShellPrompt}
 
-  val appVersion = "0.6.0-SNAPSHOT"
+  val appVersion = "0.6.0"
 
   val appDependencies = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current % "provided",

--- a/src/main/scala/uk/gov/hmrc/urls/Link.scala
+++ b/src/main/scala/uk/gov/hmrc/urls/Link.scala
@@ -16,20 +16,20 @@
 
 package uk.gov.hmrc.urls
 
-import play.twirl.api.{Html, HtmlFormat}
 import play.api.i18n.Messages
+import play.twirl.api.{Html, HtmlFormat}
 
 trait Target {
   protected val targetName: String
   def toAttr = Link.attr("target", targetName)
-  def titlePostfix = ""
+  def hiddenInfo: Option[String] = None
 }
 case object SameWindow extends Target {
   override val targetName = "_self"
 }
 case object NewWindow extends Target {
   override val targetName = "_blank"
-  override val titlePostfix = " (opens in new window)"
+  override val hiddenInfo = Some("link opens in a new window")
 }
 
 trait PossibleSso {
@@ -53,21 +53,17 @@ case class Link(url: String,
                 sso: PossibleSso = NoSso,
                 cssClasses: Option[String] = None,
                 dataAttributes: Option[Map[String, String]] = None,
-                title: Option[String] = None) {
+                hiddenInfo: Option[String] = None) {
 
-  import Link._
+  import uk.gov.hmrc.urls.Link._
 
   private def hrefAttr = attr("href", url)
   private def idAttr = id.map(attr("id", _)).getOrElse("")
 
-  private def titleAttr = title match {
-    case Some(title) => attr("title", title)
-    case _ => value.map(v => attr("title", s"${Messages(v)}${target.titlePostfix}")).getOrElse("")
-  }
-
   private def text = value.map(v => Messages(v)).getOrElse("")
   private def cssAttr = cssClasses.map(attr("class", _)).getOrElse("")
   private def dataAttr = buildAttributeString(dataAttributes)
+  private def hiddenSpanFor(txt: Option[String]) = txt.map(t => s"""<span class="hidden">${Messages(t)}</span>""").getOrElse("")
 
   def buildAttributeString(attributes: Option[Map[String, String]]): String = {
     attributes match {
@@ -79,7 +75,9 @@ case class Link(url: String,
     }
   }
 
-  def toHtml = Html(s"<a$idAttr$titleAttr$hrefAttr${target.toAttr}${sso.toAttr}$cssAttr$dataAttr>$text</a>")
+  val hiddenLink = hiddenSpanFor(hiddenInfo.orElse(target.hiddenInfo))
+
+  def toHtml = Html(s"<a$idAttr$hrefAttr${target.toAttr}${sso.toAttr}$cssAttr$dataAttr>$text$hiddenLink</a>")
 }
 
 object Link {
@@ -89,8 +87,8 @@ object Link {
   def attr(name: String, value: String) = s""" $name="${escape(value)}""""
 
   case class PreconfiguredLink(sso: PossibleSso, target: Target) {
-    def apply(url: String, value: Option[String], id: Option[String] = None, cssClasses: Option[String] = None, dataAttributes: Option[Map[String, String]] = None, title: Option[String] = None) =
-      Link(url, value, id, target, sso, cssClasses, dataAttributes, title)
+    def apply(url: String, value: Option[String], id: Option[String] = None, cssClasses: Option[String] = None, dataAttributes: Option[Map[String, String]] = None, hiddenInfo: Option[String] = None) =
+      Link(url, value, id, target, sso, cssClasses, dataAttributes, hiddenInfo)
   }
 
   def toInternalPage = PreconfiguredLink(NoSso, SameWindow)

--- a/src/test/scala/uk/gov/hmrc/urls/LinkSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/urls/LinkSpec.scala
@@ -46,7 +46,7 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
         cssClasses = Some("link-style blink"))
 
       Then("the link should be rendered with id and styles")
-      portalLink.toHtml.toString() shouldBe "<a id=\"link-id\" href=\"https://someurl\" target=\"_self\" data-sso=\"client\" class=\"link-style blink\">link text</a>"
+      portalLink.toHtml.toString() shouldBe "<a id=\"link-id\" title=\"link text\" href=\"https://someurl\" target=\"_self\" data-sso=\"client\" class=\"link-style blink\">link text</a>"
 
     }
 
@@ -59,7 +59,20 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
       val portalLink = Link.toPortalPage.apply(url = "https://someurl", value = value)
 
       Then("the link should be rendered in the same way")
-      portalLink.toHtml.toString() shouldBe "<a href=\"https://someurl\" target=\"_self\" data-sso=\"client\">Pay &pound;4,000 now - it's due</a>"
+      portalLink.toHtml.toString() shouldBe """<a title="Pay &amp;pound;4,000 now - it&#x27;s due" href="https://someurl" target="_self" data-sso="client">Pay &pound;4,000 now - it's due</a>"""
+
+    }
+
+    it("be created with the title when specified") {
+
+      Given("the title value is 'my title'")
+      val title = Some("my title")
+
+      When("portal page link is created")
+      val portalLink = Link.toPortalPage.apply(url = "https://someurl", value = None, title = title)
+
+      Then("the link should have title")
+      portalLink.toHtml.toString() shouldBe """<a title="my title" href="https://someurl" target="_self" data-sso="client"></a>"""
 
     }
   }
@@ -127,6 +140,19 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
 
       Then("the link should be rendered with no sso in a new window")
       portalLink.toHtml.toString() shouldBe "<a href=\"https://someurl\" target=\"_blank\" data-sso=\"false\"></a>"
+
+    }
+
+    it("be created with title including new window prompt for screen readers") {
+
+      Given("the link value attribute as 'Pay &pound;4,000 now - it's due'")
+      val value = Some("Pay £4,000 now - it's due")
+
+      When("external page link is created")
+      val portalLink = Link.toExternalPage.apply(url = "https://someurl", value = value)
+
+      Then("the link should be rendered with title including a new window prompt")
+      portalLink.toHtml.toString() shouldBe "<a title=\"Pay £4,000 now - it&#x27;s due (opens in new window)\" href=\"https://someurl\" target=\"_blank\" data-sso=\"false\">Pay £4,000 now - it's due</a>"
 
     }
   }

--- a/src/test/scala/uk/gov/hmrc/urls/LinkSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/urls/LinkSpec.scala
@@ -46,7 +46,7 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
         cssClasses = Some("link-style blink"))
 
       Then("the link should be rendered with id and styles")
-      portalLink.toHtml.toString() shouldBe "<a id=\"link-id\" title=\"link text\" href=\"https://someurl\" target=\"_self\" data-sso=\"client\" class=\"link-style blink\">link text</a>"
+      portalLink.toHtml.toString() shouldBe "<a id=\"link-id\" href=\"https://someurl\" target=\"_self\" data-sso=\"client\" class=\"link-style blink\">link text</a>"
 
     }
 
@@ -59,20 +59,20 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
       val portalLink = Link.toPortalPage.apply(url = "https://someurl", value = value)
 
       Then("the link should be rendered in the same way")
-      portalLink.toHtml.toString() shouldBe """<a title="Pay &amp;pound;4,000 now - it&#x27;s due" href="https://someurl" target="_self" data-sso="client">Pay &pound;4,000 now - it's due</a>"""
+      portalLink.toHtml.toString() shouldBe """<a href="https://someurl" target="_self" data-sso="client">Pay &pound;4,000 now - it's due</a>"""
 
     }
 
-    it("be created with the title when specified") {
+    it("be created with the hidden info span when specified") {
 
-      Given("the title value is 'my title'")
-      val title = Some("my title")
+      Given("the hiddenInfo value is 'my hiddenInfo'")
+      val hiddenInfo = Some("my hiddenInfo")
 
       When("portal page link is created")
-      val portalLink = Link.toPortalPage.apply(url = "https://someurl", value = None, title = title)
+      val portalLink = Link.toPortalPage.apply(url = "https://someurl", value = None, hiddenInfo = hiddenInfo)
 
-      Then("the link should have title")
-      portalLink.toHtml.toString() shouldBe """<a title="my title" href="https://someurl" target="_self" data-sso="client"></a>"""
+      Then("the link should have hidden span")
+      portalLink.toHtml.toString() shouldBe """<a href="https://someurl" target="_self" data-sso="client"><span class="hidden">my hiddenInfo</span></a>"""
 
     }
   }
@@ -139,11 +139,11 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
       val portalLink = Link.toExternalPage.apply(url = "https://someurl", value = None)
 
       Then("the link should be rendered with no sso in a new window")
-      portalLink.toHtml.toString() shouldBe "<a href=\"https://someurl\" target=\"_blank\" data-sso=\"false\"></a>"
+      portalLink.toHtml.toString() shouldBe """<a href="https://someurl" target="_blank" data-sso="false"><span class="hidden">link opens in a new window</span></a>"""
 
     }
 
-    it("be created with title including new window prompt for screen readers") {
+    it("be created with hidden info span for screen readers") {
 
       Given("the link value attribute as 'Pay &pound;4,000 now - it's due'")
       val value = Some("Pay £4,000 now - it's due")
@@ -152,7 +152,7 @@ class LinkSpec extends FunSpecLike with GivenWhenThen with Matchers {
       val portalLink = Link.toExternalPage.apply(url = "https://someurl", value = value)
 
       Then("the link should be rendered with title including a new window prompt")
-      portalLink.toHtml.toString() shouldBe "<a title=\"Pay £4,000 now - it&#x27;s due (opens in new window)\" href=\"https://someurl\" target=\"_blank\" data-sso=\"false\">Pay £4,000 now - it's due</a>"
+      portalLink.toHtml.toString() shouldBe """<a href="https://someurl" target="_blank" data-sso="false">Pay £4,000 now - it's due<span class="hidden">link opens in a new window</span></a>"""
 
     }
   }


### PR DESCRIPTION
All our links should have mouse over help and, specifically, links that open in a new window should have a hint that this is going to happen. The main driver for this is so that screen readers can let the user know what is going to happen.

This pull requests adds the ability to set a title on the link.

The title will default (if the title argument is not specified) to the link text when the link is internal and the link text with '(opens in new window)' tagged on the end when the link is external.
